### PR TITLE
feat: add React context provider, hook, and HOC for Facebook Pixel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "react-use-facebook-pixel",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-use-facebook-pixel",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.2",
+        "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "eslint": "^8.57.0",
@@ -17,10 +18,14 @@
         "eslint-plugin-prettier": "^5.2.1",
         "prettier": "^3.3.3",
         "prettier-eslint": "^16.3.0",
+        "react": "^18.2.0",
         "terser": "^5.31.5",
         "typescript": "^5.5.4",
         "vite": "^6.3.2",
         "vite-plugin-dts": "^4.5.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1293,6 +1298,24 @@
         "undici-types": "~6.11.1"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.0.0.tgz",
@@ -1813,6 +1836,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -2623,6 +2653,13 @@
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2822,6 +2859,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/lru-cache": {
@@ -3385,6 +3435,19 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "prepare": "npm run build"
   },
   "keywords": [
     "facebook",
@@ -34,6 +35,7 @@
   "author": "Eugene Medvedev",
   "devDependencies": {
     "@types/node": "^22.0.2",
+    "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "eslint": "^8.57.0",
@@ -45,5 +47,8 @@
     "typescript": "^5.5.4",
     "vite": "^6.3.2",
     "vite-plugin-dts": "^4.5.3"
+  },
+  "peerDependencies": {
+    "react": ">=16.8.0"
   }
 }

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,3 +1,6 @@
+/**
+ * https://developers.facebook.com/docs/meta-pixel/reference
+ */
 export enum TrackableEventNameEnum {
   /**
    *  When payment information is added in the checkout flow.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,10 @@ class FacebookPixel {
       return;
     }
     this.initialized = true;
+
     window.fbq('set', 'autoConfig', this.autoConfig, this.pixelID);
     window.fbq('init', this.pixelID, props);
+
     if (props.external_id) {
       this.externalId = props.external_id;
     }
@@ -72,7 +74,7 @@ class FacebookPixel {
         eventName,
         '\nEvent data: ',
         data,
-        '\nEvent additiona data',
+        '\nEvent additional data',
         additionalData
       );
     }
@@ -80,5 +82,6 @@ class FacebookPixel {
 }
 
 export { FacebookPixel, TrackableEventNameEnum };
+export { FacebookPixelProvider, useFacebookPixel, withFacebookPixel } from './provider';
 
 export type { TrackableEventName, AdditionalEventData, InitProps, EventData };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,0 +1,216 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { FacebookPixel } from './index';
+import { InitProps } from './types';
+import React from 'react';
+
+
+// Context type definition
+interface FacebookPixelContextType {
+  pixel: FacebookPixel | null;
+  isInitialized: boolean;
+}
+
+// Provider props interface  
+interface FacebookPixelProviderProps {
+  /** Your Facebook Pixel ID */
+  pixelId: string;
+  /** Enable or disable debug mode (default: true) */
+  debug?: boolean;
+  /** Automatically track PageView event on initialization (default: true) */
+  pageViewOnInit?: boolean;
+  /** Enable automatic configuration (default: true) */
+  autoConfig?: boolean;
+  /** Initial properties for pixel initialization */
+  initProps?: InitProps;
+  /** Children components */
+  children?: any;
+}
+
+// Create the context
+const FacebookPixelContext = createContext<FacebookPixelContextType | undefined>(undefined);
+
+// Singleton instance to prevent reinitialization
+let facebookPixelSingleton: { pixel: FacebookPixel; pixelId: string } | null = null;
+
+/**
+ * FacebookPixelProvider - React context provider for Facebook Pixel
+ * 
+ * This provider initializes the Facebook Pixel with the provided configuration
+ * and makes it available to child components through React context.
+ * 
+ * @example
+ * ```tsx
+ * import { FacebookPixelProvider } from 'react-use-facebook-pixel';
+ * 
+ * function App() {
+ *   return (
+ *     <FacebookPixelProvider pixelId="YOUR_PIXEL_ID">
+ *       <YourApp />
+ *     </FacebookPixelProvider>
+ *   );
+ * }
+ * ```
+ */
+export const FacebookPixelProvider = (props: FacebookPixelProviderProps) => {
+  const {
+    pixelId,
+    debug = true,
+    pageViewOnInit = true,
+    autoConfig = true,
+    initProps = {},
+    children,
+  } = props;
+
+  const [pixel, setPixel] = useState<FacebookPixel | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    // Only initialize once per pixelId
+    if (!facebookPixelSingleton || facebookPixelSingleton.pixelId !== pixelId) {
+      const initializeFacebookPixel = async () => {
+        try {
+          // Create new pixel instance
+          const newPixel = new FacebookPixel({
+            pixelID: pixelId,
+            debug,
+            pageViewOnInit,
+            autoConfig,
+          });
+
+          // Initialize the pixel
+          newPixel.init(initProps);
+
+          // Update singleton and state
+          facebookPixelSingleton = { pixel: newPixel, pixelId };
+          setPixel(newPixel);
+          setIsInitialized(true); 
+
+          if (debug) {
+            console.log(
+              '[react-use-facebook-pixel]',
+              new Date().toLocaleTimeString(),
+              'Facebook Pixel Provider initialized with ID:', 
+              pixelId
+            );
+          }
+        } catch (error) {
+          if (debug) {
+            console.error(
+              '[react-use-facebook-pixel]',
+              new Date().toLocaleTimeString(),
+              'Failed to initialize Facebook Pixel:',
+              error
+            );
+          }
+        }
+      };
+
+      initializeFacebookPixel();
+    } else {
+      // Use existing singleton
+      setPixel(facebookPixelSingleton.pixel);
+      setIsInitialized(true);
+    }
+  }, [pixelId, debug, pageViewOnInit, autoConfig, initProps]);
+
+  const contextValue: FacebookPixelContextType = {
+    pixel,
+    isInitialized,
+  };
+
+  // Use React.createElement to avoid JSX issues
+  return React.createElement(
+    FacebookPixelContext.Provider,
+    { value: contextValue },
+    children
+  );
+};
+
+/**
+ * useFacebookPixel - React hook for accessing Facebook Pixel instance
+ * 
+ * This hook provides access to the Facebook Pixel instance and initialization status.
+ * Must be used within a FacebookPixelProvider.
+ * 
+ * @returns {FacebookPixelContextType} Object containing pixel instance and initialization status
+ * 
+ * @throws {Error} When used outside of FacebookPixelProvider
+ * 
+ * @example
+ * ```tsx
+ * import { useFacebookPixel, TrackableEventNameEnum } from 'react-use-facebook-pixel';
+ * 
+ * function MyComponent() {
+ *   const { pixel, isInitialized } = useFacebookPixel();
+ * 
+ *   const handlePurchase = () => {
+ *     if (pixel && isInitialized) {
+ *       pixel.trackEvent(TrackableEventNameEnum.Purchase, {
+ *         content_ids: ['1234'],
+ *         currency: 'USD',
+ *         value: 100.0,
+ *       });
+ *     }
+ *   };
+ * 
+ *   return (
+ *     <button onClick={handlePurchase}>
+ *       Track Purchase
+ *     </button>
+ *   );
+ * }
+ * ```
+ */
+export const useFacebookPixel = (): FacebookPixelContextType => {
+  const context = useContext(FacebookPixelContext);
+  
+  if (context === undefined) {
+    throw new Error(
+      'useFacebookPixel must be used within a FacebookPixelProvider. ' +
+      'Make sure to wrap your component tree with <FacebookPixelProvider>.'
+    );
+  }
+  
+  return context;
+};
+
+/**
+ * Higher-Order Component for Facebook Pixel
+ * 
+ * This HOC automatically wraps a component with FacebookPixelProvider.
+ * Useful for quick setup without manually adding the provider.
+ * 
+ * @param WrappedComponent - Component to wrap
+ * @param pixelConfig - Facebook Pixel configuration
+ * @returns Enhanced component with Facebook Pixel context
+ * 
+ * @example
+ * ```tsx
+ * import { withFacebookPixel } from 'react-use-facebook-pixel';
+ * 
+ * const MyApp = () => <div>My App</div>;
+ * 
+ * export default withFacebookPixel(MyApp, {
+ *   pixelId: 'YOUR_PIXEL_ID',
+ *   debug: true,
+ * });
+ * ```
+ */
+export const withFacebookPixel = <P extends object>(
+  WrappedComponent: any,
+  pixelConfig: Omit<FacebookPixelProviderProps, 'children'>
+) => {
+  const WithFacebookPixelComponent = (props: P) => {
+    return React.createElement(
+      FacebookPixelProvider,
+      pixelConfig,
+      React.createElement(WrappedComponent, props)
+    );
+  };
+
+  WithFacebookPixelComponent.displayName = `withFacebookPixel(${
+    WrappedComponent.displayName || WrappedComponent.name || 'Component'
+  })`;
+
+  return WithFacebookPixelComponent;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     },
     sourcemap: true,
     rollupOptions: {
-      external: [],
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
     },
   },
 });


### PR DESCRIPTION
- Adds FacebookPixelProvider to initialize and provide pixel instance via context
- Exports useFacebookPixel hook and withFacebookPixel HOC for easier integration
- Improves React usage flexibility without reinitialization

Generated-by: aiautocommit
